### PR TITLE
Fixed publishing ancestors of a related item.

### DIFF
--- a/src/Sitecore.Support.131687/Publishing/Pipelines/GetItemReferences/AddItemLinkReferences.cs
+++ b/src/Sitecore.Support.131687/Publishing/Pipelines/GetItemReferences/AddItemLinkReferences.cs
@@ -72,7 +72,10 @@ namespace Sitecore.Support.Publishing.Pipelines.GetItemReferences
 
       foreach (var relatedItem in relatedItems)
       {
-        result.AddRange(PublishQueue.GetParents(relatedItem));
+        if (!relatedItem.Paths.IsContentItem)
+        {
+          result.AddRange(PublishQueue.GetParents(relatedItem));
+        }       
         result.Add(relatedItem);
       }
 


### PR DESCRIPTION
Ancestors of a related item are published now if only a related item is
not a content item.